### PR TITLE
feat: Rewrite docker-compose.yml and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,52 @@
-# Required
-MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/database?retryWrites=true
-MONGODB_METRICS=mongodb+srv://username:password@cluster.mongodb.net/metrics?retryWrites=true
-FANART_API=your_fanart_api_key_here
-TMDB_API=your_tmdb_api_key_here
-HOST_NAME=http://localhost:1337
+# --- Stremio TMDB Addon Environment Variables ---
 
-# Optional
+# -- General Configuration --
+# The port the addon will run on.
+# Default: 3000
 PORT=3000
-NODE_ENV=development
 
-# Analytics Configuration
-METRICS_USER=admin
-METRICS_PASSWORD=your_secure_password_here
+# The publicly accessible URL for this addon (e.g., http://your-domain.com or http://your-ip:3000).
+# This is required for the manifest.json to work correctly.
+# Default: http://127.0.0.1:3000
+HOST_NAME=http://127.0.0.1:3000
+
+# -- API Keys --
+# The Movie Database (TMDB) API Key.
+# Get one for free at https://www.themoviedb.org/settings/api
+TMDB_API=
+
+# Fanart.tv API Key.
+# Optional, but recommended for better images.
+# Get one at https://fanart.tv/get-an-api-key
+FANART_API=
+
+# -- Caching --
+# The connection URL for your Redis instance.
+# The docker-compose setup provides a Redis service, so this should work out of the box.
+# Format: redis://[user:password@]host:port[/db-number]
+# Default: redis://127.0.0.1:6379
+REDIS_URL=redis://tmdb-redis:6379
+
+# Time-to-live (TTL) for metadata cache in seconds.
+# Default: 604800 (7 days)
+META_TTL=604800
+
+# Time-to-live (TTL) for catalog cache in seconds.
+# Default: 86400 (1 day)
+CATALOG_TTL=86400
+
+# Set to "true" to disable all caching. Useful for development.
+# Default: false
+NO_CACHE=false
+
+# -- Metrics (Optional) --
+# Basic authentication credentials for the /metrics endpoint exposed by swagger-stats.
+# If you want to protect your metrics, set a username and password.
+METRICS_USER=
+METRICS_PASSWORD=
+
+# -- GitHub (Optional) --
+# These variables seem to be related to a specific, non-essential feature.
+# You can likely leave them blank unless you know what they are for.
+GITHUB_TOKEN=
+GITHUB_REPO=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,26 @@
-version: '3'
+version: '3.8'
+
 services:
   tmdb-addon:
     build: .
     container_name: tmdb-addon
     ports:
-      - "3000:3000"
+      - "${PORT:-3000}:3000"
     env_file:
       - .env
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
+
+  redis:
+    image: redis:alpine
+    container_name: tmdb-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
The docker-compose.yml has been updated to include a Redis service for caching, aligning with the application's current dependencies. The port mapping is now dynamic, and a health check ensures service startup order.

A comprehensive .env.example file has been created to guide users in setting up the required environment variables, including API keys and caching configurations.