### PR TITLE
Refactor: Replace hardcoded catalog names with dynamic generation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -310,8 +310,6 @@ addon.get("/debug/test-types", function (req, res) {
     'movie',
     'series', 
     'tv',
-    'Detaylı Filtre (Film) 🔎',
-    'Detaylı Filtre (Dizi) 🔎',
     'unknown'
   ];
   
@@ -392,9 +390,7 @@ addon.get("/debug/test-flow", async function (req, res) {
   const typeTests = [
     'movie',
     'series', 
-    'tv',
-    'Detaylı Filtre (Film) 🔎',
-    'Detaylı Filtre (Dizi) 🔎'
+    'tv'
   ];
   
   testResults.tests.push({
@@ -457,11 +453,11 @@ addon.get("/debug/test-flow", async function (req, res) {
     });
   }
 
-  // Test 3: Config parsing with Turkish types
+  // Test 3: Config parsing
   try {
     const testConfigs = [
-      '{"language":"tr-TR","catalogs":[{"type":"Detaylı Filtre (Film) 🔎","id":"tmdb.top"}]}',
-      '{"language":"en-US","catalogs":[{"type":"movie","id":"tmdb.top"}]}'
+      '{"language":"en-US","catalogs":[{"type":"movie","id":"tmdb.top"}]}',
+      '{"language":"tr-TR","catalogs":[{"type":"series","id":"tmdb.top"}]}'
     ];
     
     const configResults = testConfigs.map(configStr => {
@@ -471,7 +467,7 @@ addon.get("/debug/test-flow", async function (req, res) {
           input: configStr,
           parsed: config,
           hasValidTypes: config.catalogs?.every(cat => 
-            ['movie', 'series', 'Detaylı Filtre (Film) 🔎', 'Detaylı Filtre (Dizi) 🔎'].includes(cat.type)
+            ['movie', 'series'].includes(cat.type)
           )
         };
       } catch (e) {
@@ -490,32 +486,6 @@ addon.get("/debug/test-flow", async function (req, res) {
     });
   }
 
-  // Test 4: Test endpoint for old config compatibility
-  try {
-    const testOldConfig = '{"language":"tr-TR","catalogs":[{"type":"Detaylı Filtre (Film) 🔎","id":"tmdb.top","enabled":true,"showInHome":true},{"type":"Detaylı Filtre (Dizi) 🔎","id":"tmdb.trending","enabled":true,"showInHome":false}]}';
-    
-    const { parseConfig } = require("./utils/parseProps");
-    const { toCanonicalType } = require('./utils/typeCanonical');
-    
-    const parsedConfig = parseConfig(testOldConfig);
-    
-    testResults.tests.push({
-      name: "Old Config Compatibility",
-      original: testOldConfig,
-      parsed: parsedConfig,
-      typesFixed: parsedConfig.catalogs ? parsedConfig.catalogs.map(cat => ({
-        originalType: cat.type,
-        isCanonical: ['movie', 'series'].includes(cat.type),
-        wouldCanonicalizeAs: toCanonicalType(cat.type)
-      })) : [],
-      success: parsedConfig.catalogs ? parsedConfig.catalogs.every(cat => ['movie', 'series'].includes(cat.type)) : false
-    });
-  } catch (error) {
-    testResults.tests.push({
-      name: "Old Config Compatibility",
-      error: error.message
-    });
-  }
 
   res.json(testResults);
 });
@@ -799,9 +769,7 @@ addon.get("/debug/test-functions", async function (req, res) {
     // Test 1: Type canonicalization
     const { toCanonicalType } = require('./utils/typeCanonical');
     const typeTests = [
-      'movie', 'series', 'tv', 
-      'Detaylı Filtre (Film) 🔎', 
-      'Detaylı Filtre (Dizi) 🔎'
+      'movie', 'series', 'tv'
     ].map(type => ({
       input: type,
       output: toCanonicalType(type),
@@ -860,7 +828,7 @@ addon.get("/debug/test-functions", async function (req, res) {
     const { parseConfig } = require('./utils/parseProps');
     const testConfigs = [
       '{"language":"tr-TR","catalogs":[{"type":"movie","id":"tmdb.top"}]}',
-      '{"language":"tr-TR","catalogs":[{"type":"Detaylı Filtre (Film) 🔎","id":"tmdb.top"}]}'
+      '{"language":"en-US","catalogs":[{"type":"series","id":"tmdb.top"}]}'
     ];
     
     const configTests = testConfigs.map(configStr => {
@@ -968,7 +936,7 @@ addon.get("/debug/test-all-functionality", async function (req, res) {
     });
 
     // Test 5: Type canonicalization verification
-    const testTypes = ['movie', 'series', 'tv', 'Detaylı Filtre (Film) 🔎', 'Detaylı Filtre (Dizi) 🔎'];
+    const testTypes = ['movie', 'series', 'tv'];
     testResults.tests.push({
       name: "Type Canonicalization",
       success: true,

--- a/addon/lib/getLogo.js
+++ b/addon/lib/getLogo.js
@@ -2,7 +2,10 @@ require('dotenv').config();
 const FanartTvApi = require("fanart.tv-api");
 const apiKey = process.env.FANART_API;
 const baseUrl = "http://webservice.fanart.tv/v3/";
-const fanart = new FanartTvApi({ apiKey, baseUrl });
+let fanart;
+if (apiKey) {
+  fanart = new FanartTvApi({ apiKey, baseUrl });
+}
 
 const { MovieDb } = require("moviedb-promise");
 const moviedb = new MovieDb(process.env.TMDB_API);
@@ -23,17 +26,19 @@ async function getLogo(tmdbId, language, originalLanguage) {
     throw new Error(`TMDB ID not available for logo: ${tmdbId}`);
   }
 
-  const [fanartRes, tmdbRes] = await Promise.all([
-    fanart
-      .getMovieImages(tmdbId)
-      .then(res => res.hdmovielogo || [])
-      .catch(() => []),
+  const fanartPromise = fanart
+    ? fanart
+        .getMovieImages(tmdbId)
+        .then(res => res.hdmovielogo || [])
+        .catch(() => [])
+    : Promise.resolve([]);
 
-    moviedb
-      .movieImages({ id: tmdbId })
-      .then(res => res.logos || [])
-      .catch(() => [])
-  ]);
+  const tmdbPromise = moviedb
+    .movieImages({ id: tmdbId })
+    .then(res => res.logos || [])
+    .catch(() => []);
+
+  const [fanartRes, tmdbRes] = await Promise.all([fanartPromise, tmdbPromise]);
 
   const fanartLogos = fanartRes.map(l => ({
     url: l.url,
@@ -60,21 +65,22 @@ async function getTvLogo(tvdb_id, tmdbId, language, originalLanguage) {
     throw new Error(`TVDB ID and TMDB ID not available for logos.`);
   }
 
-  const [fanartRes, tmdbRes] = await Promise.all([
-    tvdb_id
+  const fanartPromise =
+    fanart && tvdb_id
       ? fanart
           .getShowImages(tvdb_id)
           .then(res => res.hdtvlogo || [])
           .catch(() => [])
-      : Promise.resolve([]),
+      : Promise.resolve([]);
 
-    tmdbId
-      ? moviedb
-          .tvImages({ id: tmdbId })
-          .then(res => res.logos || [])
-          .catch(() => [])
-      : Promise.resolve([])
-  ]);
+  const tmdbPromise = tmdbId
+    ? moviedb
+        .tvImages({ id: tmdbId })
+        .then(res => res.logos || [])
+        .catch(() => [])
+    : Promise.resolve([]);
+
+  const [fanartRes, tmdbRes] = await Promise.all([fanartPromise, tmdbPromise]);
 
   const fanartLogos = fanartRes.map(l => ({
     url: l.url,

--- a/addon/utils/typeCanonical.js
+++ b/addon/utils/typeCanonical.js
@@ -1,12 +1,5 @@
 // Utility to map display label or type to canonical type ("movie" or "series")
-const typeLabels = {
-  movie: "Detaylı Filtre (Film) 🔎",
-  series: "Detaylı Filtre (Dizi) 🔎"
-};
-
 const labelToType = {
-  [typeLabels.movie]: "movie",
-  [typeLabels.series]: "series",
   movie: "movie",
   series: "series",
   tv: "series"  // Handle TMDB API inconsistency

--- a/configure/src/utils/typeLabels.ts
+++ b/configure/src/utils/typeLabels.ts
@@ -1,8 +1,8 @@
 // Type labels mapping for display purposes (does not affect API type values)
-// This mapping ensures consistent Turkish labels across the frontend UI
+// This mapping ensures consistent labels across the frontend UI
 export const TYPE_LABELS = {
-  movie: "Detaylı Filtre (Film) 🔎",
-  series: "Detaylı Filtre (Dizi) 🔎"
+  movie: "Movie",
+  series: "Series"
 } as const;
 
 export type ContentType = keyof typeof TYPE_LABELS;


### PR DESCRIPTION
This commit refactors the catalog generation logic to remove hardcoded Turkish names and replace them with dynamically generated, translatable names.

Key changes include:
- Removing the "Detaylı Filtre (Film) 🔎" and "Detaylı Filtre (Dizi) 🔎" labels from `getManifest.js`, `typeCanonical.js`, and `typeLabels.ts`.
- Updating `createCatalog` in `getManifest.js` to build catalog names from translated keys (e.g., "Popular", "Trending") and the content type ("Movies", "Series"). A check is included to prevent duplicate type names in the final string.
- Cleaning up debug endpoints in `addon/index.js` to remove references to the old, hardcoded names.
- Making the Fanart.tv API integration in `getLogo.js` optional to prevent server crashes when the API key is not provided.
- Adding error handling to the `getGenreList` API calls in `getManifest.js` to improve resilience against API failures.

This change addresses the user's request to use original catalog names and improves the maintainability and internationalization of the addon.